### PR TITLE
Automatic session renegotiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ function SimplerPeer (opts) {
 
   EventEmitter.call(this)
 
-  this._initiator = opts.initiator
   this._trickle = opts.trickle !== undefined ? opts.trickle : true
 
   this._onSetRemoteDescription = this._onSetRemoteDescription.bind(this)
@@ -48,14 +47,18 @@ function SimplerPeer (opts) {
   this.connection.onaddstream = this._onaddStream.bind(this)
   this.connection.onnegotiationneeded = this._onNegotiationNeeded.bind(this)
 
-  if (opts.stream) {
-    this.connection.addStream(opts.stream)
+  if (opts.initiator) {
+    this.connect()
+  }
+}
+
+SimplerPeer.prototype.connect = function (signal) {
+  if (this._channel) {
+    throw new Error('connection already initialized')
   }
 
-  if (this._initiator) {
-    this._channel = this.createDataChannel('internal')
-    this._channel.once('open', this._onChannelOpen)
-  }
+  this._channel = this.createDataChannel('internal')
+  this._channel.once('open', this._onChannelOpen)
 }
 
 SimplerPeer.prototype.signal = function (signal) {

--- a/index.js
+++ b/index.js
@@ -71,8 +71,8 @@ SimplerPeer.prototype.signal = function (signal) {
 
   if (signal.sdp) {
     this._processRemoteSessionDescription(signal)
-  } else if (signal.candidate) {
-    this._processRemoteIceCandidate(signal.candidate)
+  } else {
+    this._processRemoteIceCandidate(signal)
   }
 }
 
@@ -276,7 +276,7 @@ SimplerPeer.prototype._onIceCandidate = function (evt) {
 
   if (this.trickle) {
     if (evt.candidate) {
-      this.emit('signal', evt)
+      this.emit('signal', evt.candidate)
     }
   } else {
     clearTimeout(this._iceGatheringTimeout)

--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ function SimplerPeer (opts) {
   this._opts = {
     iceServers: [
       {
-        url: 'stun:23.21.150.121',
-        urls: 'stun:23.21.150.121'
+        url: 'stun:217.10.68.152',
+        urls: 'stun:217.10.68.152'
       }
     ]
   }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var webrtc = require('get-browser-rtc')()
 var inherits = require('inherits')
 var EventEmitter = require('events').EventEmitter
 var DataChannel = require('./data-channel')
-var sessionVersionRegex = /\no=- [^ ]* ([^ ]*)/
+var sessionVersionRegex = /\no=[^ ]* [^ ]* ([^ ]*)/
 
 inherits(SimplerPeer, EventEmitter)
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,29 @@ function SimplerPeer (opts) {
     throw new Error('your browser does not support WebRTC')
   }
 
+  EventEmitter.call(this)
+
+  ;[
+    '_onSetRemoteDescription',
+    '_onSetLocalDescription',
+    '_onSetRemoteAnswer',
+    '_onSetLocalAnswer',
+    '_onCreateOffer',
+    '_onCreateAnswer',
+    '_onChannelOpen',
+    '_onChannelMessage',
+    '_onIceComplete',
+    '_onDataChannel',
+    '_onIceCandidate',
+    '_onIceConnectionStateChange',
+    '_onNegotiationNeeded',
+    '_onTrack',
+    '_onError',
+    'close',
+  ].forEach(method => {
+    this[method] = this[method].bind(this)
+  })
+
   opts = opts || {}
   opts.config = opts.config || {
     iceServers: [
@@ -27,31 +50,17 @@ function SimplerPeer (opts) {
     ]
   }
 
-  EventEmitter.call(this)
-
-  this._onSetRemoteDescription = this._onSetRemoteDescription.bind(this)
-  this._onSetLocalDescription = this._onSetLocalDescription.bind(this)
-  this._onSetRemoteAnswer = this._onSetRemoteAnswer.bind(this)
-  this._onSetLocalAnswer = this._onSetLocalAnswer.bind(this)
-  this._onCreateOffer = this._onCreateOffer.bind(this)
-  this._onCreateAnswer = this._onCreateAnswer.bind(this)
-  this._onChannelOpen = this._onChannelOpen.bind(this)
-  this._onChannelMessage = this._onChannelMessage.bind(this)
-  this._onIceComplete = this._onIceComplete.bind(this)
-  this._onError = this._onError.bind(this)
-  this.close = this.close.bind(this)
-
   this.id = opts.id || (Math.random() + '').slice(2)
   this.trickle = opts.trickle !== undefined ? opts.trickle : true
   this.remoteStreams = {}
   this.remoteStreamIds = {}
   this.remoteTrackIds = {}
   this.connection = new webrtc.RTCPeerConnection(opts.config)
-  this.connection.ondatachannel = this._onDataChannel.bind(this)
-  this.connection.onicecandidate = this._onIceCandidate.bind(this)
-  this.connection.oniceconnectionstatechange = this._onIceConnectionStateChange.bind(this)
-  this.connection.onnegotiationneeded = this._onNegotiationNeeded.bind(this)
-  this.connection[this.connection.addTrack ? 'ontrack' : 'onaddstream'] = this._onTrack.bind(this)
+  this.connection.ondatachannel = this._onDataChannel
+  this.connection.onicecandidate = this._onIceCandidate
+  this.connection.oniceconnectionstatechange = this._onIceConnectionStateChange
+  this.connection.onnegotiationneeded = this._onNegotiationNeeded
+  this.connection[this.connection.addTrack ? 'ontrack' : 'onaddstream'] = this._onTrack
 
   if (opts.initiator) {
     this.connect()

--- a/index.js
+++ b/index.js
@@ -29,8 +29,6 @@ function SimplerPeer (opts) {
 
   EventEmitter.call(this)
 
-  this._trickle = opts.trickle !== undefined ? opts.trickle : true
-
   this._onSetRemoteDescription = this._onSetRemoteDescription.bind(this)
   this._onSetLocalDescription = this._onSetLocalDescription.bind(this)
   this._onCreateOffer = this._onCreateOffer.bind(this)
@@ -40,6 +38,7 @@ function SimplerPeer (opts) {
   this._onError = this._onError.bind(this)
 
   this.id = opts.id || (Math.random() + '').slice(2)
+  this.trickle = opts.trickle !== undefined ? opts.trickle : true
   this.connection = new webrtc.RTCPeerConnection(opts.config)
   this.connection.ondatachannel = this._onDataChannel.bind(this)
   this.connection.onicecandidate = this._onIceCandidate.bind(this)
@@ -241,7 +240,7 @@ SimplerPeer.prototype._onCreateAnswer = function (answer) {
     this._channel.send(
       JSON.stringify(answer)
     )
-  } else if (this._trickle) {
+  } else if (this.trickle) {
     this.emit('signal', answer)
   }
 
@@ -265,7 +264,7 @@ SimplerPeer.prototype._onSetLocalDescription = function () {
       noop,
       this._onError
     )
-  } else if (this._trickle) {
+  } else if (this.trickle) {
     this.emit('signal', this.connection.localDescription)
   }
 }
@@ -275,7 +274,7 @@ SimplerPeer.prototype._onIceCandidate = function (evt) {
 
   debug(this.id, 'onIceCandidate', evt)
 
-  if (this._trickle) {
+  if (this.trickle) {
     if (evt.candidate) {
       this.emit('signal', evt)
     }
@@ -311,7 +310,7 @@ SimplerPeer.prototype._onIceComplete = function () {
 
   debug(this.id, 'onIceComplete')
 
-  if (!this._trickle) {
+  if (!this.trickle) {
     this.emit('signal', this.connection.localDescription)
   }
 }

--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ SimplerPeer.prototype._onSetLocalAnswer = function () {
       if (track.readyState !== undefined) return
       if (!this.remoteTrackIds[track.id]) {
         track.onended && track.onended()
-        track.dispatchEvent(new Event('ended'))
+        track.dispatchEvent(new window.Event('ended'))
       }
     })
     if (!this.remoteStreamIds[id]) {
@@ -424,7 +424,7 @@ SimplerPeer.prototype._onTrack = function (evt) {
   } else {
     evt = {
       track: evt.stream.getTracks()[0],
-      streams: [ evt.stream ],
+      streams: [ evt.stream ]
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var webrtc = require('get-browser-rtc')()
 var inherits = require('inherits')
 var EventEmitter = require('events').EventEmitter
 var DataChannel = require('./data-channel')
-var sessionVersionRegex = /\no=[^ ]* [^ ]* ([^ ]*)/
+var sessionRegex = /\no=[^ ]* ([^ ]*) ([^ ]*)/
 
 inherits(SimplerPeer, EventEmitter)
 
@@ -31,20 +31,27 @@ function SimplerPeer (opts) {
 
   this._onSetRemoteDescription = this._onSetRemoteDescription.bind(this)
   this._onSetLocalDescription = this._onSetLocalDescription.bind(this)
+  this._onSetRemoteAnswer = this._onSetRemoteAnswer.bind(this)
+  this._onSetLocalAnswer = this._onSetLocalAnswer.bind(this)
   this._onCreateOffer = this._onCreateOffer.bind(this)
   this._onCreateAnswer = this._onCreateAnswer.bind(this)
   this._onChannelOpen = this._onChannelOpen.bind(this)
   this._onChannelMessage = this._onChannelMessage.bind(this)
+  this._onIceComplete = this._onIceComplete.bind(this)
   this._onError = this._onError.bind(this)
+  this.close = this.close.bind(this)
 
   this.id = opts.id || (Math.random() + '').slice(2)
   this.trickle = opts.trickle !== undefined ? opts.trickle : true
+  this.remoteStreams = {}
+  this.remoteStreamIds = {}
+  this.remoteTrackIds = {}
   this.connection = new webrtc.RTCPeerConnection(opts.config)
   this.connection.ondatachannel = this._onDataChannel.bind(this)
   this.connection.onicecandidate = this._onIceCandidate.bind(this)
   this.connection.oniceconnectionstatechange = this._onIceConnectionStateChange.bind(this)
-  this.connection.onaddstream = this._onaddStream.bind(this)
   this.connection.onnegotiationneeded = this._onNegotiationNeeded.bind(this)
+  this.connection[this.connection.addTrack ? 'ontrack' : 'onaddstream'] = this._onTrack.bind(this)
 
   if (opts.initiator) {
     this.connect()
@@ -82,16 +89,30 @@ SimplerPeer.prototype.createDataChannel = function (label, opts) {
   return new DataChannel(this.connection.createDataChannel(label, opts))
 }
 
-SimplerPeer.prototype.addStream = function (stream) {
-  debug(this.id, 'addStream', stream)
+SimplerPeer.prototype.addTrack = function (track, firstStream) {
+  debug(this.id, 'addTrack', track)
 
-  this.connection.addStream(stream)
+  this.negotiationNeeded = true
+  if (this.connection.addTrack) {
+    return this.connection.addTrack.apply(
+      this.connection,
+      arguments
+    )
+  } else {
+    this.connection.addStream(firstStream)
+    return firstStream
+  }
 }
 
-SimplerPeer.prototype.removeStream = function (stream) {
-  debug(this.id, 'removeStream', stream)
+SimplerPeer.prototype.removeTrack = function (sender) {
+  debug(this.id, 'removeTrack', sender)
 
-  this.connection.removeStream(stream)
+  this.negotiationNeeded = true
+  if (this.connection.removeTrack) {
+    this.connection.removeTrack(sender)
+  } else {
+    this.connection.removeStream(sender)
+  }
 }
 
 SimplerPeer.prototype.close = function () {
@@ -114,12 +135,23 @@ SimplerPeer.prototype.close = function () {
 
 // private API below
 
-SimplerPeer.prototype._onNegotiationNeeded = function () {
-  debug(this.id, 'onNegotiationNeeded')
+SimplerPeer.prototype._onNegotiationNeeded = function (evt) {
+  if (this.closed) return
+
+  debug(this.id, 'onNegotiationNeeded', !!evt, !!this._localOffer, !!this._remoteOffer)
 
   this.emit('negotiationneeded')
 
-  delete this._localOffer
+  if (this._localOffer || this._remoteOffer) {
+    if (this._localOffer && this._localOffer.sdp) {
+      this.negotiationNeeded = true
+    }
+    return
+  } else {
+    delete this.negotiationNeeded
+  }
+
+  this._localOffer = {}
   this.connection.createOffer(
     this._onCreateOffer,
     this._onError
@@ -127,8 +159,6 @@ SimplerPeer.prototype._onNegotiationNeeded = function () {
 }
 
 SimplerPeer.prototype._onCreateOffer = function (offer) {
-  if (this.closed) return
-
   debug(this.id, 'onCreateOffer', offer)
 
   this._localOffer = offer
@@ -147,23 +177,41 @@ SimplerPeer.prototype._onCreateOffer = function (offer) {
 }
 
 SimplerPeer.prototype._processRemoteSessionDescription = function (signal) {
+  // workaround for FF not triggering track.onended
+  this.remoteStreamIds = {}
+  this.remoteTrackIds = {}
+  signal.sdp.split('msid:').slice(1).forEach(line => {
+    var parts = line.split(' ')
+    this.remoteStreamIds[parts[0]] = true
+    this.remoteTrackIds[parts[1]] = true
+  })
+
   if (signal.type === 'offer') {
     this._processRemoteOffer(signal)
-  } else if (signal.type === 'answer' && this._localOffer) {
+  } else if (signal.type === 'answer') {
     this._processRemoteAnswer(signal)
   }
 }
 
 SimplerPeer.prototype._processRemoteOffer = function (offer) {
-  debug(this.id, 'got offer', offer)
-
-  if (this._remoteOffer) {
-    this._remoteOffer = offer
-    return
-  } else {
-    this._remoteOffer = offer
+  if (this._localOffer && !this._remoteAnswer) {
+    if (this.connection.signalingState === 'have-local-offer') {
+      this._onError(new Error('sdp rollback not yet supported'))
+      this.close()
+      return
+    }
+    var didChooseLocalOffer = this._compareOffers(this._localOffer, offer)
+    delete this._localOffer
+    if (didChooseLocalOffer) {
+      return
+    } else {
+      this.negotiationNeeded = true
+    }
   }
 
+  debug(this.id, 'got offer', offer)
+
+  this._remoteOffer = offer
   this.connection.setRemoteDescription(
     new webrtc.RTCSessionDescription(offer),
     this._onSetRemoteDescription,
@@ -171,57 +219,11 @@ SimplerPeer.prototype._processRemoteOffer = function (offer) {
   )
 }
 
-SimplerPeer.prototype._processRemoteAnswer = function (answer) {
-  var remoteSessionVersion = answer.sdp.match(sessionVersionRegex)[1]
-  var localSessionVersion = this._localOffer.sdp.match(sessionVersionRegex)[1]
-  if (remoteSessionVersion !== localSessionVersion) {
-    return
-  }
-
-  debug(this.id, 'got answer', answer)
-
-  this._remoteAnswer = new webrtc.RTCSessionDescription(answer)
-  var offer = this._localOffer
-  delete this._localOffer
-
-  if (this.connected) {
-    this.connection.setLocalDescription(
-      offer,
-      this._onSetLocalDescription,
-      this._onError
-    )
-  } else {
-    this._onSetLocalDescription()
-  }
-}
-
-SimplerPeer.prototype._processRemoteIceCandidate = function (candidate) {
-  debug(this.id, 'got candidate', candidate)
-
-  this.connection.addIceCandidate(
-    new webrtc.RTCIceCandidate(candidate),
-    noop,
-    this._onError
-  )
-}
-
-SimplerPeer.prototype._hasLatestOffer = function () {
-  var latestSessionVersion = this._remoteOffer.sdp.match(sessionVersionRegex)[1]
-  var currentSessionVersion = this.connection.remoteDescription.sdp.match(sessionVersionRegex)[1]
-  if (latestSessionVersion === currentSessionVersion) {
-    return true
-  }
-
-  debug(this.id, 'found later offer', this._remoteOffer)
-
-  var offer = this._remoteOffer
-  delete this._remoteOffer
-  this._processRemoteOffer(offer)
+SimplerPeer.prototype._compareOffers = function (a, b) {
+  return a.sdp.match(sessionRegex)[1] > b.sdp.match(sessionRegex)[1]
 }
 
 SimplerPeer.prototype._onSetRemoteDescription = function () {
-  if (this.closed || !this._hasLatestOffer()) return
-
   debug(this.id, 'onSetRemoteDescription')
 
   this.connection.createAnswer(
@@ -231,10 +233,9 @@ SimplerPeer.prototype._onSetRemoteDescription = function () {
 }
 
 SimplerPeer.prototype._onCreateAnswer = function (answer) {
-  if (this.closed || !this._hasLatestOffer()) return
-  delete this._remoteOffer
-
   debug(this.id, 'onCreateAnswer', answer)
+
+  delete this._remoteOffer
 
   if (this.connected) {
     this._channel.send(
@@ -246,14 +247,50 @@ SimplerPeer.prototype._onCreateAnswer = function (answer) {
 
   this.connection.setLocalDescription(
     answer,
-    noop,
+    this._onSetLocalAnswer,
     this._onError
   )
 }
 
-SimplerPeer.prototype._onSetLocalDescription = function () {
-  if (this.closed) return
+SimplerPeer.prototype._onSetLocalAnswer = function () {
+  // workaround for FF not triggering track.onended
+  for (var id in this.remoteStreams) {
+    var stream = this.remoteStreams[id]
+    stream.getTracks().forEach(track => {
+      if (track.readyState !== undefined) return
+      if (!this.remoteTrackIds[track.id]) {
+        track.onended && track.onended()
+        track.dispatchEvent(new Event('ended'))
+      }
+    })
+    if (!this.remoteStreamIds[id]) {
+      delete this.remoteStreams[id]
+    }
+  }
 
+  delete this._localOffer
+  this._checkNegotiationNeeded()
+}
+
+SimplerPeer.prototype._processRemoteAnswer = function (answer) {
+  if (!this._localOffer) return
+
+  debug(this.id, 'got answer', answer)
+
+  this._remoteAnswer = new webrtc.RTCSessionDescription(answer)
+
+  if (this.connected) {
+    this.connection.setLocalDescription(
+      this._localOffer,
+      this._onSetLocalDescription,
+      this._onError
+    )
+  } else {
+    this._onSetLocalDescription()
+  }
+}
+
+SimplerPeer.prototype._onSetLocalDescription = function () {
   debug(this.id, 'onSetLocalDescription')
 
   if (this._remoteAnswer) {
@@ -261,12 +298,34 @@ SimplerPeer.prototype._onSetLocalDescription = function () {
     delete this._remoteAnswer
     this.connection.setRemoteDescription(
       answer,
-      noop,
+      this._onSetRemoteAnswer,
       this._onError
     )
   } else if (this.trickle) {
     this.emit('signal', this.connection.localDescription)
   }
+}
+
+SimplerPeer.prototype._onSetRemoteAnswer = function () {
+  delete this._localOffer
+  this._checkNegotiationNeeded()
+}
+
+SimplerPeer.prototype._checkNegotiationNeeded = function () {
+  if (this.negotiationNeeded) {
+    delete this.negotiationNeeded
+    this._onNegotiationNeeded()
+  }
+}
+
+SimplerPeer.prototype._processRemoteIceCandidate = function (candidate) {
+  debug(this.id, 'got candidate', candidate)
+
+  this.connection.addIceCandidate(
+    new webrtc.RTCIceCandidate(candidate),
+    noop,
+    this._onError
+  )
 }
 
 SimplerPeer.prototype._onIceCandidate = function (evt) {
@@ -283,7 +342,7 @@ SimplerPeer.prototype._onIceCandidate = function (evt) {
     if (!evt.candidate) {
       this._onIceComplete()
     } else {
-      this._iceGatheringTimeout = setTimeout(this._onIceComplete.bind(this), 250)
+      this._iceGatheringTimeout = setTimeout(this._onIceComplete, 250)
     }
   }
 }
@@ -305,6 +364,8 @@ SimplerPeer.prototype._onIceConnectionStateChange = function (evt) {
 }
 
 SimplerPeer.prototype._onIceComplete = function () {
+  if (this.closed) return
+
   this.connection.onicecandidate = null
   this._onIceComplete = noop
 
@@ -336,7 +397,7 @@ SimplerPeer.prototype._onChannelOpen = function () {
 
   debug(this.id, 'connect')
 
-  this._channel.on('close', this.close.bind(this))
+  this._channel.on('close', this.close)
   this._channel.on('message', this._onChannelMessage)
   this.connected = true
   this.emit('connect')
@@ -345,17 +406,27 @@ SimplerPeer.prototype._onChannelOpen = function () {
 SimplerPeer.prototype._onChannelMessage = function (evt) {
   if (this.closed) return
 
-  debug(this.id, 'onChannelMessage', evt)
+  debug(this.id, 'onChannelMessage', evt.data)
 
   this.signal(evt.data)
 }
 
-SimplerPeer.prototype._onaddStream = function (evt) {
+SimplerPeer.prototype._onTrack = function (evt) {
   if (this.closed) return
 
-  debug(this.id, 'onaddStream', evt.stream)
+  debug(this.id, 'onTrack', evt)
 
-  this.emit('stream', evt.stream)
+  if (this.connection.addTrack) {
+    var remoteStream = evt.streams[0]
+    this.remoteStreams[remoteStream.id] = remoteStream
+  } else {
+    evt = {
+      track: evt.stream.getTracks()[0],
+      streams: [ evt.stream ],
+    }
+  }
+
+  this.emit('track', evt)
 }
 
 SimplerPeer.prototype._onError = function (err) {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ function SimplerPeer (opts) {
   this._remoteStreams = {}
   this._remoteStreamIds = {}
   this._remoteTrackIds = {}
+  this._senders = {}
 }
 
 // public API
@@ -131,7 +132,7 @@ SimplerPeer.prototype.addTrack = function (track, stream) {
     this._localTracks[track.id] = track
   }
   if (this.connection.addTrack) {
-    track._sender = this.connection.addTrack(
+    this._senders[track.id] = this.connection.addTrack(
       track,
       stream
     )
@@ -156,7 +157,8 @@ SimplerPeer.prototype.removeTrack = function (track) {
     delete this._localTracks[track.id]
   }
   if (this.connection.removeTrack) {
-    this.connection.removeTrack(track._sender)
+    this.connection.removeTrack(this._senders[track.id])
+    delete this._senders[track.id]
   } else {
     this.connection.removeStream(track._stream)
   }

--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ function SimplerPeer (opts) {
 
 SimplerPeer.prototype.connect = function (signal) {
   if (this._channel) {
-    throw new Error('connection already initialized')
+    this._onError(new Error('connection already initialized'))
+    return
   }
 
   this._channel = this.createDataChannel('internal')
@@ -70,6 +71,7 @@ SimplerPeer.prototype.connect = function (signal) {
 SimplerPeer.prototype.signal = function (signal) {
   if (this.closed) {
     this._onError(new Error('cannot signal after connection has closed'))
+    return
   }
 
   if (typeof signal === 'string') {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "inherits": "^2.0.1"
   },
   "devDependencies": {
+    "standard": "^7.1.2",
     "tape": "^4.0.1",
     "zuul": "^3.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.2.0",
   "description": "A fork of Feross's simple-peer that doesn't touch node streams or Buffer",
   "scripts": {
-    "test": "standard && zuul --ui tape --no-coverage --local 7357 ./test.js"
+    "test": "watchify test.js -o test-build.js",
+    "lint": "standard index.js data-channel.js test.js"
   },
   "dependencies": {
     "get-browser-rtc": "^1.0.2",
@@ -11,9 +12,9 @@
   },
   "devDependencies": {
     "standard": "^7.1.2",
-    "tape": "^4.0.1",
-    "zuul": "^3.2.0"
+    "tape": "^4.6.0",
+    "watchify": "^3.7.0"
   },
   "author": "jesse.tane@gmail.com",
-  "license": "ISC"
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "inherits": "^2.0.1"
   },
   "devDependencies": {
-    "standard": "^7.1.2",
-    "tape": "^4.6.0",
-    "watchify": "^3.7.0"
+    "standard": "^12.0.1",
+    "tape": "^4.11.0",
+    "watchify": "^3.11.1"
   },
   "author": "jesse.tane@gmail.com",
   "license": "MIT"

--- a/test.html
+++ b/test.html
@@ -1,0 +1,1 @@
+<script src=test-build.js></script>

--- a/test.js
+++ b/test.js
@@ -122,8 +122,8 @@ tape('close without trickle', function (t) {
 tape('renegotiation triggered by addStream', function (t) {
   t.plan(4)
 
-  p1 = new SimplerPeer({ id: 'p1', initiator: true })
-  p2 = new SimplerPeer({ id: 'p2' })
+  p1 = new SimplerPeer({ initiator: true })
+  p2 = new SimplerPeer()
 
   p1.on('signal', function (signal) {
     p2.signal(signal)

--- a/test.js
+++ b/test.js
@@ -74,7 +74,7 @@ tape('close', function (t) {
   p2.close()
 })
 
-tape('trickle connect', function (t) {
+tape('connect without trickle ice', function (t) {
   t.plan(4)
 
   p1 = new SimplerPeer({ initiator: true, trickle: false })
@@ -104,7 +104,7 @@ tape('trickle connect', function (t) {
   })
 })
 
-tape('trickle close', function (t) {
+tape('close without trickle', function (t) {
   t.plan(2)
 
   p1.on('close', function () {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var SimplerPeer = require('./')
 var tape = require('tape')
 
-var ctx = new AudioContext()
+var ctx = new window.AudioContext()
 var p1 = null
 var p2 = null
 
@@ -146,7 +146,7 @@ tape('handle session renegotiation when addTrack is called', function (t) {
     })
 
     var stream = ctx.createMediaStreamDestination().stream
-    var sender = p1.addTrack(stream.getTracks()[0], stream)
+    p1.addTrack(stream.getTracks()[0], stream)
   }
 
   function onaddTrack () {
@@ -236,8 +236,8 @@ tape('handle session renegotiation when offers are received by both sides simult
 
     var stream1 = ctx.createMediaStreamDestination().stream
     var stream2 = ctx.createMediaStreamDestination().stream
-    var sender1 = p1.addTrack(stream1.getTracks()[0], stream1)
-    var sender2 = p2.addTrack(stream2.getTracks()[0], stream2)
+    p1.addTrack(stream1.getTracks()[0], stream1)
+    p2.addTrack(stream2.getTracks()[0], stream2)
   }
 
   var o = 2
@@ -288,7 +288,7 @@ tape('handle session renegotiation when offers are received by both sides simult
 
     // actually add a stream from p2
     var stream = ctx.createMediaStreamDestination().stream
-    var sender = p2.addTrack(stream.getTracks()[0], stream)
+    p2.addTrack(stream.getTracks()[0], stream)
   }
 
   function onaddTrack () {

--- a/test.js
+++ b/test.js
@@ -1,15 +1,33 @@
-var SimplerPeer = require('./')
 var tape = require('tape')
+var Peer = require('./')
 
 var ctx = new window.AudioContext()
 var p1 = null
 var p2 = null
 
-tape('connect', function (t) {
+tape('not connect if peer ids are equal', function (t) {
   t.plan(2)
 
-  p1 = new SimplerPeer({ initiator: true })
-  p2 = new SimplerPeer()
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 1 })
+
+  p1.on('error', function (err) {
+    t.ok(err)
+  })
+
+  p2.on('error', function (err) {
+    t.ok(err)
+  })
+
+  p1.connect(p2.id)
+  p2.connect(p1.id)
+})
+
+tape('connect, disconnect and reconnect', function (t) {
+  t.plan(6)
+
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
 
   p1.on('signal', function (signal) {
     p2.signal(signal)
@@ -20,105 +38,94 @@ tape('connect', function (t) {
   })
 
   p1.on('connect', function () {
-    t.pass('p1 connected')
+    onconnect()
   })
 
   p2.on('connect', function () {
-    t.pass('p2 connected')
+    onconnect()
   })
+
+  p1.on('disconnect', function () {
+    t.pass('p1 did disconnect')
+  })
+
+  p2.on('disconnect', function () {
+    t.pass('p2 did disconnect')
+    if (connectionsNeeded > 0) {
+      connect()
+    }
+  })
+
+  var connectionsNeeded = 4
+
+  connect()
+
+  function connect () {
+    p1.connect(p2.id)
+    p2.connect(p1.id)
+  }
+
+  function onconnect () {
+    if (--connectionsNeeded === 2) {
+      t.pass('did connect')
+      p1.disconnect()
+    } else if (connectionsNeeded === 0) {
+      t.pass('did connect')
+      p1.disconnect()
+    }
+  }
 })
 
-tape('open a data channel and be able to send and receive binary data', function (t) {
+tape('use data channels', function (t) {
   t.plan(6)
 
-  p1.testChannel = p1.createDataChannel('test-channel')
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
 
-  p1.testChannel.on('message', function (evt) {
-    var data = evt.data
-    t.equal(data instanceof ArrayBuffer, true)
-    data = new Uint8Array(data)
-    t.equal(data[0], 1)
-    t.equal(data[1], 127)
-    t.equal(data[2], 255)
+  p1.on('signal', function (signal) {
+    p2.signal(signal)
   })
 
-  p1.testChannel.send('wow')
+  p2.on('signal', function (signal) {
+    p1.signal(signal)
+  })
+
+  p1.on('connect', function (track) {
+    var testChannel = p1.createDataChannel('test-channel')
+    testChannel.on('message', function (evt) {
+      var data = evt.data
+      t.equal(data instanceof ArrayBuffer, true)
+      data = new Uint8Array(data)
+      t.equal(data[0], 1)
+      t.equal(data[1], 127)
+      t.equal(data[2], 255)
+      p1.disconnect()
+    })
+    testChannel.send('wow')
+  })
 
   p2.on('datachannel', function (channel) {
-    t.equal(channel.label, 'test-channel', 'p2 saw channel open')
-    p2.testChannel = channel
-
-    p2.testChannel.on('message', function (evt) {
+    t.equal(channel.label, 'test-channel')
+    channel.on('message', function (evt) {
       t.equal(evt.data, 'wow')
       var buffer = new ArrayBuffer(3)
       var view = new Uint8Array(buffer)
       view[0] = 1
       view[1] = 127
       view[2] = 255
-      p2.testChannel.send(buffer)
+      channel.send(buffer)
     })
   })
+
+  p1.connect(p2.id)
+  p2.connect(p1.id)
 })
 
-tape('trigger a close event when closed', function (t) {
-  t.plan(2)
-
-  p1.on('close', function () {
-    t.pass('p1 closed')
-  })
-
-  p2.on('close', function () {
-    t.pass('p2 closed')
-  })
-
-  p1.close()
-  p2.close()
-})
-
-tape('connect with trickle ice disabled', function (t) {
-  t.plan(4)
-
-  p1 = new SimplerPeer({ initiator: true, trickle: false })
-  p2 = new SimplerPeer({ trickle: false })
-
-  var p1DidSignal = false
-  var p2DidSignal = false
-
-  p1.on('signal', function (signal) {
-    t.equal(p1DidSignal, false, 'p1 should only get one signal')
-    p1DidSignal = true
-    p2.signal(signal)
-  })
-
-  p2.on('signal', function (signal) {
-    t.equal(p2DidSignal, false, 'p2 should only get one signal')
-    p2DidSignal = true
-    p1.signal(signal)
-  })
-
-  p1.on('connect', function () {
-    t.pass('p1 connected')
-    onconnect()
-  })
-
-  p2.on('connect', function () {
-    t.pass('p2 connected')
-    onconnect()
-  })
-
-  var n = 2
-  function onconnect () {
-    if (--n !== 0) return
-    p1.close()
-    p2.close()
-  }
-})
-
-tape('handle session renegotiation when addTrack is called', function (t) {
+tape('add media tracks from the initiator side before connect', function (t) {
   t.plan(1)
 
-  p1 = new SimplerPeer({ initiator: true })
-  p2 = new SimplerPeer()
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
 
   p1.on('signal', function (signal) {
     p2.signal(signal)
@@ -128,38 +135,23 @@ tape('handle session renegotiation when addTrack is called', function (t) {
     p1.signal(signal)
   })
 
-  p1.on('connect', function () {
-    onconnect()
+  p1.on('track', function (track) {
+    t.ok(track, 'got remote track')
+    p1.disconnect()
   })
 
-  p2.on('connect', function () {
-    onconnect()
-  })
+  var stream = ctx.createMediaStreamDestination().stream
+  p2.addTrack(stream.getTracks()[0], stream)
 
-  var n = 2
-  function onconnect () {
-    if (--n !== 0) return
-
-    p2.on('track', function (evt) {
-      t.ok(evt.track)
-      onaddTrack()
-    })
-
-    var stream = ctx.createMediaStreamDestination().stream
-    p1.addTrack(stream.getTracks()[0], stream)
-  }
-
-  function onaddTrack () {
-    p1.close()
-    p2.close()
-  }
+  p1.connect(p2.id)
+  p2.connect(p1.id)
 })
 
-tape('handle session renegotiation when removeTrack is called', function (t) {
-  t.plan(2)
+tape('add media tracks from the non-initiator side before connect', function (t) {
+  t.plan(1)
 
-  p1 = new SimplerPeer({ initiator: true })
-  p2 = new SimplerPeer()
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
 
   p1.on('signal', function (signal) {
     p2.signal(signal)
@@ -169,90 +161,23 @@ tape('handle session renegotiation when removeTrack is called', function (t) {
     p1.signal(signal)
   })
 
-  p1.on('connect', function () {
-    onconnect()
+  p2.on('track', function (track) {
+    t.ok(track, 'got remote track')
+    p1.disconnect()
   })
 
-  p2.on('connect', function () {
-    onconnect()
-  })
+  var stream = ctx.createMediaStreamDestination().stream
+  p1.addTrack(stream.getTracks()[0], stream)
 
-  var n = 2
-  function onconnect () {
-    if (--n !== 0) return
-
-    p2.on('track', function (evt) {
-      t.ok(evt.track)
-      evt.track.onended = ontrackEnded
-      p1.removeTrack(sender)
-    })
-
-    var stream = ctx.createMediaStreamDestination().stream
-    var sender = p1.addTrack(stream.getTracks()[0], stream)
-  }
-
-  function ontrackEnded () {
-    t.pass()
-    p1.close()
-    p2.close()
-  }
+  p1.connect(p2.id)
+  p2.connect(p1.id)
 })
 
-tape('handle session renegotiation when offers are received by both sides simultaneously', function (t) {
-  t.plan(2)
+tape('add media tracks from the initiator side after connect', function (t) {
+  t.plan(1)
 
-  p1 = new SimplerPeer({ initiator: true })
-  p2 = new SimplerPeer()
-
-  p1.on('signal', function (signal) {
-    p2.signal(signal)
-  })
-
-  p2.on('signal', function (signal) {
-    p1.signal(signal)
-  })
-
-  p1.on('connect', function () {
-    onconnect()
-  })
-
-  p2.on('connect', function () {
-    onconnect()
-  })
-
-  var n = 2
-  function onconnect () {
-    if (--n !== 0) return
-
-    p1.on('track', function (evt) {
-      t.ok(evt.track)
-      onaddTrack()
-    })
-
-    p2.on('track', function (evt) {
-      t.ok(evt.track)
-      onaddTrack()
-    })
-
-    var stream1 = ctx.createMediaStreamDestination().stream
-    var stream2 = ctx.createMediaStreamDestination().stream
-    p1.addTrack(stream1.getTracks()[0], stream1)
-    p2.addTrack(stream2.getTracks()[0], stream2)
-  }
-
-  var o = 2
-  function onaddTrack () {
-    if (--o !== 0) return
-    p1.close()
-    p2.close()
-  }
-})
-
-tape('handle session renegotiation when offers are received by both sides simultaneously but the winning offer carries fewer than the required number of m-lines', function (t) {
-  t.plan(2)
-
-  p1 = new SimplerPeer({ initiator: true })
-  p2 = new SimplerPeer()
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
 
   p1.on('signal', function (signal) {
     p2.signal(signal)
@@ -262,38 +187,168 @@ tape('handle session renegotiation when offers are received by both sides simult
     p1.signal(signal)
   })
 
-  p1.on('connect', function () {
-    onconnect()
-  })
-
   p2.on('connect', function () {
-    onconnect()
-  })
-
-  var n = 2
-  function onconnect () {
-    if (--n !== 0) return
-
-    p1.on('track', function (evt) {
-      t.ok(evt.track)
-      onaddTrack()
-    })
-
-    // force p1's offer to always win
-    p1._compareOffers = function (a, b) { return true }
-    p2._compareOffers = function (a, b) { return false }
-
-    // manually force p1 to renegotiate
-    p1._onNegotiationNeeded()
-
-    // actually add a stream from p2
     var stream = ctx.createMediaStreamDestination().stream
     p2.addTrack(stream.getTracks()[0], stream)
+  })
+
+  p1.on('track', function (track) {
+    t.ok(track, 'got remote track')
+    p1.disconnect()
+  })
+
+  p1.connect(p2.id)
+  p2.connect(p1.id)
+})
+
+tape('add media tracks from the non-initiator side after connect', function (t) {
+  t.plan(1)
+
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
+
+  p1.on('signal', function (signal) {
+    p2.signal(signal)
+  })
+
+  p2.on('signal', function (signal) {
+    p1.signal(signal)
+  })
+
+  p1.on('connect', function () {
+    var stream = ctx.createMediaStreamDestination().stream
+    p1.addTrack(stream.getTracks()[0], stream)
+  })
+
+  p2.on('track', function (track) {
+    t.ok(track, 'got remote track')
+    p1.disconnect()
+  })
+
+  p1.connect(p2.id)
+  p2.connect(p1.id)
+})
+
+tape('remove media tracks from the initiator side', function (t) {
+  t.plan(2)
+
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
+
+  p1.on('signal', function (signal) {
+    p2.signal(signal)
+  })
+
+  p2.on('signal', function (signal) {
+    p1.signal(signal)
+  })
+
+  p2.on('connect', function () {
+    var stream = ctx.createMediaStreamDestination().stream
+    track = stream.getTracks()[0]
+    p2.addTrack(track, stream)
+  })
+
+  p1.on('track', function (evt) {
+    t.ok(evt.track, 'got remote track')
+    evt.track.onended = function () {
+      t.pass('remote track ended')
+      p1.disconnect()
+    }
+    p2.removeTrack(track)
+  })
+
+  var track = null
+
+  p1.connect(p2.id)
+  p2.connect(p1.id)
+})
+
+tape('remove media tracks from the non-initiator side', function (t) {
+  t.plan(2)
+
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
+
+  p1.on('signal', function (signal) {
+    p2.signal(signal)
+  })
+
+  p2.on('signal', function (signal) {
+    p1.signal(signal)
+  })
+
+  p1.on('connect', function () {
+    var stream = ctx.createMediaStreamDestination().stream
+    track = stream.getTracks()[0]
+    p1.addTrack(track, stream)
+  })
+
+  p2.on('track', function (evt) {
+    t.ok(evt.track, 'got remote track')
+    evt.track.onended = function () {
+      t.pass('remote track ended')
+      p2.disconnect()
+    }
+    p1.removeTrack(track)
+  })
+
+  var track = null
+
+  p1.connect(p2.id)
+  p2.connect(p1.id)
+})
+
+tape('re-add media tracks automatically after reconnect', function (t) {
+  t.plan(6)
+
+  p1 = new Peer({ id: 1 })
+  p2 = new Peer({ id: 2 })
+
+  p1.on('signal', function (signal) {
+    p2.signal(signal)
+  })
+
+  p2.on('signal', function (signal) {
+    p1.signal(signal)
+  })
+
+  p1.on('connect', function () {
+    onconnect()
+  })
+
+  p2.on('connect', function () {
+    onconnect()
+  })
+
+  p1.on('track', function (track) {
+    t.ok(track, 'got remote track')
+    p1.disconnect()
+  })
+
+  p2.on('disconnect', function () {
+    t.pass('p2 did disconnect')
+    if (connectionsNeeded > 0) {
+      connect()
+    }
+  })
+
+  var connectionsNeeded = 4
+
+  connect()
+
+  function connect () {
+    p1.connect(p2.id)
+    p2.connect(p1.id)
   }
 
-  function onaddTrack () {
-    t.pass()
-    p1.close()
-    p2.close()
+  function onconnect () {
+    if (--connectionsNeeded === 2) {
+      t.pass('did connect once')
+      var stream = ctx.createMediaStreamDestination().stream
+      p2.addTrack(stream.getTracks()[0], stream)
+    } else if (connectionsNeeded === 0) {
+      t.pass('did connect twice')
+    }
   }
 })

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ tape('connect', function (t) {
   })
 })
 
-tape('data', function (t) {
+tape('open a data channel and be able to send and receive binary data', function (t) {
   t.plan(6)
 
   p1.testChannel = p1.createDataChannel('test-channel')
@@ -59,7 +59,7 @@ tape('data', function (t) {
   })
 })
 
-tape('close', function (t) {
+tape('trigger a close event when closed', function (t) {
   t.plan(2)
 
   p1.on('close', function () {
@@ -74,7 +74,7 @@ tape('close', function (t) {
   p2.close()
 })
 
-tape('connect without trickle ice', function (t) {
+tape('connect with trickle ice disabled', function (t) {
   t.plan(4)
 
   p1 = new SimplerPeer({ initiator: true, trickle: false })
@@ -97,130 +97,23 @@ tape('connect without trickle ice', function (t) {
 
   p1.on('connect', function () {
     t.pass('p1 connected')
+    onconnect()
   })
 
   p2.on('connect', function () {
     t.pass('p2 connected')
-  })
-})
-
-tape('close without trickle', function (t) {
-  t.plan(2)
-
-  p1.on('close', function () {
-    t.pass('p1 closed')
-  })
-
-  p2.on('close', function () {
-    t.pass('p2 closed')
-  })
-
-  p1.close()
-  p2.close()
-})
-
-tape('renegotiation triggered by addStream', function (t) {
-  t.plan(4)
-
-  p1 = new SimplerPeer({ initiator: true })
-  p2 = new SimplerPeer()
-
-  p1.on('signal', function (signal) {
-    p2.signal(signal)
-  })
-
-  p2.on('signal', function (signal) {
-    p1.signal(signal)
-  })
-
-  p1.on('connect', function () {
-    t.pass('p1 connected')
-    connect()
-  })
-
-  p2.on('connect', function () {
-    t.pass('p2 connected')
-    connect()
+    onconnect()
   })
 
   var n = 2
-  function connect () {
+  function onconnect () {
     if (--n !== 0) return
-
-    var ctx = new AudioContext()
-
-    var stream1 = ctx.createMediaStreamDestination().stream
-    p1.on('stream', function (stream) {
-      t.ok(stream)
-      addStream()
-    })
-
-    var stream2 = ctx.createMediaStreamDestination().stream
-    p2.on('stream', function (stream) {
-      t.ok(stream)
-      addStream()
-    })
-
-    p1.addStream(stream1)
-    p2.addStream(stream2)
-  }
-
-  var o = 2
-  function addStream () {
-    if (--o !== 0) return
     p1.close()
     p2.close()
   }
 })
 
-tape('renegotiation triggered by removeStream', function (t) {
-  t.plan(4)
-
-  p1 = new SimplerPeer({ initiator: true })
-  p2 = new SimplerPeer()
-
-  p1.on('signal', function (signal) {
-    p2.signal(signal)
-  })
-
-  p2.on('signal', function (signal) {
-    p1.signal(signal)
-  })
-
-  p1.on('connect', function () {
-    t.pass('p1 connected')
-    connect()
-  })
-
-  p2.on('connect', function () {
-    t.pass('p2 connected')
-    connect()
-  })
-
-  var n = 2
-  function connect () {
-    if (--n !== 0) return
-
-    var ctx = new AudioContext()
-
-    p2.on('stream', function (stream) {
-      t.ok(stream)
-      stream.onended = removeStream
-      p1.removeStream(stream1)
-    })
-
-    var stream1 = ctx.createMediaStreamDestination().stream
-    p1.addStream(stream1)
-  }
-
-  function removeStream () {
-    t.pass()
-    p1.close()
-    p2.close()
-  }
-})
-
-tape('renegotiation only uses the latest of multiple offers', function (t) {
+tape('automatically handle session renegotiation when addStream is called', function (t) {
   t.plan(3)
 
   p1 = new SimplerPeer({ initiator: true })
@@ -236,32 +129,174 @@ tape('renegotiation only uses the latest of multiple offers', function (t) {
 
   p1.on('connect', function () {
     t.pass('p1 connected')
-    connect()
+    onconnect()
   })
 
   p2.on('connect', function () {
     t.pass('p2 connected')
-    connect()
+    onconnect()
   })
 
   var n = 2
-  function connect () {
+  function onconnect () {
     if (--n !== 0) return
 
-    var ctx = new AudioContext()
-
-    var stream1 = ctx.createMediaStreamDestination().stream
-    p1.on('stream', function (stream) {
-      t.ok(stream)
-      addStream()
+    p2.on('stream', function (remoteStream) {
+      t.ok(remoteStream)
+      onaddStream()
     })
 
+    var ctx = new AudioContext()
+    var stream = ctx.createMediaStreamDestination().stream
+    p1.addStream(stream)
+  }
+
+  function onaddStream () {
+    p1.close()
+    p2.close()
+  }
+})
+
+tape('automatically handle session renegotiation when removeStream is called', function (t) {
+  t.plan(4)
+
+  p1 = new SimplerPeer({ initiator: true })
+  p2 = new SimplerPeer()
+
+  p1.on('signal', function (signal) {
+    p2.signal(signal)
+  })
+
+  p2.on('signal', function (signal) {
+    p1.signal(signal)
+  })
+
+  p1.on('connect', function () {
+    t.pass('p1 connected')
+    onconnect()
+  })
+
+  p2.on('connect', function () {
+    t.pass('p2 connected')
+    onconnect()
+  })
+
+  var n = 2
+  function onconnect () {
+    if (--n !== 0) return
+
+    p2.on('stream', function (remoteStream) {
+      t.ok(remoteStream)
+      remoteStream.onended = onstreamEnded
+      p1.removeStream(stream)
+    })
+
+    var ctx = new AudioContext()
+    var stream = ctx.createMediaStreamDestination().stream
+    p1.addStream(stream)
+  }
+
+  function onstreamEnded () {
+    t.pass()
+    p1.close()
+    p2.close()
+  }
+})
+
+tape('automatically handle session renegotiation when addStream is called by both sides simultaneously', function (t) {
+  t.plan(4)
+
+  p1 = new SimplerPeer({ initiator: true })
+  p2 = new SimplerPeer()
+
+  p1.on('signal', function (signal) {
+    p2.signal(signal)
+  })
+
+  p2.on('signal', function (signal) {
+    p1.signal(signal)
+  })
+
+  p1.on('connect', function () {
+    t.pass('p1 connected')
+    onconnect()
+  })
+
+  p2.on('connect', function () {
+    t.pass('p2 connected')
+    onconnect()
+  })
+
+  var n = 2
+  function onconnect () {
+    if (--n !== 0) return
+
+    p1.on('stream', function (remoteStream) {
+      t.ok(remoteStream)
+      onaddStream()
+    })
+
+    p2.on('stream', function (remoteStream) {
+      t.ok(remoteStream)
+      onaddStream()
+    })
+
+    var ctx = new AudioContext()
+    var stream1 = ctx.createMediaStreamDestination().stream
+    p1.addStream(stream1)
     var stream2 = ctx.createMediaStreamDestination().stream
-    p2.on('stream', function (stream) {
+    p2.addStream(stream2)
+  }
+
+  var o = 2
+  function onaddStream () {
+    if (--o !== 0) return
+    p1.close()
+    p2.close()
+  }
+})
+
+tape('only uses the latest of multiple offers during automatic session renegotiation', function (t) {
+  t.plan(3)
+
+  p1 = new SimplerPeer({ initiator: true })
+  p2 = new SimplerPeer()
+
+  p1.on('signal', function (signal) {
+    p2.signal(signal)
+  })
+
+  p2.on('signal', function (signal) {
+    p1.signal(signal)
+  })
+
+  p1.on('connect', function () {
+    t.pass('p1 connected')
+    onconnect()
+  })
+
+  p2.on('connect', function () {
+    t.pass('p2 connected')
+    onconnect()
+  })
+
+  var n = 2
+  function onconnect () {
+    if (--n !== 0) return
+
+    p1.on('stream', function (remoteStream) {
+      t.ok(remoteStream)
+      onaddStream()
+    })
+
+    p2.on('stream', function (remoteStream) {
       t.fail()
     })
 
+    var ctx = new AudioContext()
+    var stream1 = ctx.createMediaStreamDestination().stream
     p1.addStream(stream1)
+    var stream2 = ctx.createMediaStreamDestination().stream
     p2.addStream(stream2)
 
     // this will cause p2 to get multiple offers
@@ -269,7 +304,7 @@ tape('renegotiation only uses the latest of multiple offers', function (t) {
     p1.removeStream(stream1)
   }
 
-  function addStream () {
+  function onaddStream () {
     p1.close()
     p2.close()
   }


### PR DESCRIPTION
When adding or removing media streams after the initial connection via `Peer#addStream`, session renegotiation is required. It's possible to achieve this using the same external signaling mechanism that was used for bootstrapping, however this is less than optimal. SimplerPeer always keeps a reliable data channel open internally that can be used to handle renegotiation without reliance on external systems. This technique is not only more efficient that falling back to out-of-band signaling, it is also blazing fast :)
